### PR TITLE
Add possibility to pass a parameter to the confirmAction

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ ember install:addon ember-confirm-extension
   <button>Destroy Earth</button>
 {{/confirm-extension}}
 ```
+If you want to pass a parameter to the `confirmAction` you can use the `confirmActionParam` property:
+
+```handlebars
+{{#confirm-extension questionText='Do you really want to destroy the planet?' confirmText='Yes' declineText='No' confirmAction='destroyPlanet' confirmActionParam="Earth"}}
+  <button>Destroy planet</button>
+{{/confirm-extension}}
+```
 
 ## Styling
 

--- a/addon/components/confirm-extension.js
+++ b/addon/components/confirm-extension.js
@@ -43,7 +43,7 @@ export default Ember.Component.extend({
     },
     confirm: function() {
       this.set('confirmMode', false);
-      this.sendAction('confirmAction');
+      this.sendAction('confirmAction', this.get('confirmActionParam'));
     },
     decline: function() {
       this.set('confirmMode', false);

--- a/tests/unit/components/confirm-extension-test.js
+++ b/tests/unit/components/confirm-extension-test.js
@@ -73,6 +73,26 @@ test('click on confirm triggers the confirmAction, leaves confirmMode and hides 
   assert.equal($component.find('.ece-bubble').length, 0);
 });
 
+test('When an confirmActionParam is defined, it is passed to the confirmAction', function(assert) {
+  assert.expect(1);
+
+  var targetObject = {
+    externalAction: function(confirmActionParam) {
+      assert.equal(confirmActionParam, "Test");
+    }
+  };
+
+  var component = this.subject({
+    confirmMode: true,
+    confirmAction: 'externalAction',
+    targetObject: targetObject,
+    confirmActionParam: 'Test'
+  });
+
+  var $component = this.render();
+  $component.find('.ece-confirm').click();
+});
+
 test('click on <body> should leave confirmMode when initially open', function (assert) {
   assert.expect(2);
   var component = this.subject({


### PR DESCRIPTION
Usage: 

``` javascript
{{#confirm-extension 
  confirmAction="confirm" 
  questionText='Do you really want to destroy the planet?'
  confirmText='Yes' 
  declineText='No' 
  actionParam="I need this param"}}
  click me!
{{/confirm-extension}}
```
